### PR TITLE
The issue here was with the "Database" directory already containing a…

### DIFF
--- a/bin/Debug/DNNQuickSite.vshost.application
+++ b/bin/Debug/DNNQuickSite.vshost.application
@@ -14,7 +14,7 @@
           <dsig:Transform Algorithm="urn:schemas-microsoft-com:HashTransforms.Identity" />
         </dsig:Transforms>
         <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-        <dsig:DigestValue>ZS5GmHt1R97u5gazzWdXjhBIeoE=</dsig:DigestValue>
+        <dsig:DigestValue>DDDpqPaM52+bqO4Di2rborZQoHU=</dsig:DigestValue>
       </hash>
     </dependentAssembly>
   </dependency>

--- a/bin/Debug/DNNQuickSite.vshost.exe.manifest
+++ b/bin/Debug/DNNQuickSite.vshost.exe.manifest
@@ -43,14 +43,14 @@
     </dependentAssembly>
   </dependency>
   <dependency>
-    <dependentAssembly dependencyType="install" allowDelayedBinding="true" codebase="DNNQuickSite.exe" size="76800">
+    <dependentAssembly dependencyType="install" allowDelayedBinding="true" codebase="DNNQuickSite.exe" size="77312">
       <assemblyIdentity name="DNNQuickSite" version="1.0.0.0" language="neutral" processorArchitecture="msil" />
       <hash>
         <dsig:Transforms>
           <dsig:Transform Algorithm="urn:schemas-microsoft-com:HashTransforms.Identity" />
         </dsig:Transforms>
         <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-        <dsig:DigestValue>ehe6+U5L1DaUEt3aLJhJhvjSOw8=</dsig:DigestValue>
+        <dsig:DigestValue>phxZPntGFUUMzvyFPnt47No1qYE=</dsig:DigestValue>
       </hash>
     </dependentAssembly>
   </dependency>


### PR DESCRIPTION
… database.  With a working DB, the directory is unable to be deleted and recreated without first deleting the database in MSSQL.  So that is what we have done.  We enumerate the directory to determine the existence of a database.  if it exists, we drop the database in MSSQL (which also deletes the MDF and LDF files).  At that point we can move forward cleanly without error.  Resolves #28