### PR TITLE
Determined a way to dynamically add/remove tabs and enable/disable th…

### DIFF
--- a/Start.cs
+++ b/Start.cs
@@ -29,8 +29,11 @@ namespace DNNQuickSite
 
             tabControl.SelectedIndex = 0;
             tabSiteInfo.Enabled = false;
+            tabControl.TabPages.Remove(tabSiteInfo);
             tabDatabaseInfo.Enabled = false;
+            tabControl.TabPages.Remove(tabDatabaseInfo);
             tabProgress.Enabled = false;
+            tabControl.TabPages.Remove(tabProgress);
 
             //FeedParser parser = new FeedParser();
             //var releases = parser.Parse("http://dotnetnuke.codeplex.com/project/feeds/rss?ProjectRSSFeed=codeplex%3a%2f%2frelease%2fdotnetnuke", FeedType.RSS);
@@ -168,6 +171,7 @@ namespace DNNQuickSite
             if (txtLocalInstallPackage.Text != "")
             {
                 tabInstallPackage.Enabled = false;
+                tabControl.TabPages.Insert(1, tabSiteInfo);
                 tabSiteInfo.Enabled = true;
                 tabDatabaseInfo.Enabled = false;
                 tabProgress.Enabled = false;
@@ -210,6 +214,7 @@ namespace DNNQuickSite
         private void btnSiteInfoBack_Click(object sender, EventArgs e)
         {
             tabSiteInfo.Enabled = false;
+            tabControl.TabPages.Remove(tabSiteInfo);
             tabInstallPackage.Enabled = true;
             tabControl.SelectedIndex = 0;
         }
@@ -239,6 +244,7 @@ namespace DNNQuickSite
                 {
                     tabInstallPackage.Enabled = false;
                     tabSiteInfo.Enabled = false;
+                    tabControl.TabPages.Insert(2, tabDatabaseInfo);
                     tabDatabaseInfo.Enabled = true;
                     tabProgress.Enabled = false;
                     tabControl.SelectedIndex = 2;
@@ -291,6 +297,7 @@ namespace DNNQuickSite
             tabInstallPackage.Enabled = false;
             tabSiteInfo.Enabled = true;
             tabDatabaseInfo.Enabled = false;
+            tabControl.TabPages.Remove(tabDatabaseInfo);
             tabControl.SelectedIndex = 1;
         }
 
@@ -301,6 +308,7 @@ namespace DNNQuickSite
                 tabInstallPackage.Enabled = false;
                 tabSiteInfo.Enabled = false;
                 tabDatabaseInfo.Enabled = false;
+                tabControl.TabPages.Insert(3, tabProgress);
                 tabProgress.Enabled = true;
                 lblProgress.Visible = true;
                 progressBar.Visible = true;

--- a/bin/Debug/DNNQuickSite.vshost.application
+++ b/bin/Debug/DNNQuickSite.vshost.application
@@ -14,7 +14,7 @@
           <dsig:Transform Algorithm="urn:schemas-microsoft-com:HashTransforms.Identity" />
         </dsig:Transforms>
         <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-        <dsig:DigestValue>j7wZJi/BWDqdSz0aq39/M/BwFto=</dsig:DigestValue>
+        <dsig:DigestValue>2dv1hBmU61jp1iydznrZkpDXCkg=</dsig:DigestValue>
       </hash>
     </dependentAssembly>
   </dependency>

--- a/bin/Debug/DNNQuickSite.vshost.exe.manifest
+++ b/bin/Debug/DNNQuickSite.vshost.exe.manifest
@@ -50,7 +50,7 @@
           <dsig:Transform Algorithm="urn:schemas-microsoft-com:HashTransforms.Identity" />
         </dsig:Transforms>
         <dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
-        <dsig:DigestValue>MGT2Jc93XuFtV+cSwUN3fFdG21s=</dsig:DigestValue>
+        <dsig:DigestValue>KpJOssPeyLJ3h2m2P7dI01Bfl+Q=</dsig:DigestValue>
       </hash>
     </dependentAssembly>
   </dependency>

--- a/obj/Debug/DNNQuickSite.csproj.FileListAbsolute.txt
+++ b/obj/Debug/DNNQuickSite.csproj.FileListAbsolute.txt
@@ -22,4 +22,3 @@ C:\Dev\DNNQuickSite\DNNQuickSite\obj\Debug\DNNQuickSite.exe.manifest
 C:\Dev\DNNQuickSite\DNNQuickSite\obj\Debug\DNNQuickSite.application
 C:\Dev\DNNQuickSite\DNNQuickSite\obj\Debug\DNNQuickSite.exe
 C:\Dev\DNNQuickSite\DNNQuickSite\obj\Debug\DNNQuickSite.pdb
-C:\Dev\DNNQuickSite\DNNQuickSite\obj\Debug\DNNQuickSite.csprojResolveAssemblyReference.cache


### PR DESCRIPTION
…e controls within a tab.  Now the next tab in the workflow doesn't show until it is time for it to show.  When a user clicks the Back button, the tab is removed and the previous tab is enabled.  When a previous tab is clicked, the user can view contents of the tab, but the controls are only enabled on the forward-most workflow tab.  Resolves #41